### PR TITLE
Correct license file overwriting readme files when both are present & toml "license" key misprint

### DIFF
--- a/hatch_pyinstaller/builder.py
+++ b/hatch_pyinstaller/builder.py
@@ -116,5 +116,5 @@ class PyInstallerBuilder(BuilderInterface):
         if self.metadata.core.license_files:
             extra_files.extend(self.metadata.core.license_files)
         for f in extra_files:
-            shutil.copy2(f, dist_dir)
+            shutil.copy2(f, Path(directory, project_name + '_' + f))
         return os.fspath(dist_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 name = "hatch-pyinstaller"
 dependencies = ["hatchling", "PyInstaller"]
 requires-python = ">= 3.7"
-licence = "GPL 2.0"
+#license = "GPL 2.0"
 readme = "README.md"
 keywords = ["hatch", "packaging"]
 authors = [{ name = "William Smith", email = "williams@citisyn.net" }]


### PR DESCRIPTION
extra_files is constructed with readme & license file.
Yet, when copied to directory, they are copied with the same name (= project_name), meaning the last copied file overwrites the first one.
Both should be copied as disctint files, thus this proposal to append their original name.