### PR TITLE
Add possibility to use absolute path in pyinstaller options + Simplify pyinstaller_options() function

### DIFF
--- a/hatch_pyinstaller/builder.py
+++ b/hatch_pyinstaller/builder.py
@@ -51,7 +51,7 @@ class PyInstallerConfig(BuilderConfig):
                     values = [values]
 
                 for value in values:
-                    build_options.extend([f'--{option}', value])
+                    build_options.append(f'--{option}={value}')
         return build_options
 
 


### PR DESCRIPTION
Remove call to relative path normalization. All path options, including "--paths", "--add-data" & "--add-binaries" can use absolute paths, in which case split(':)' fails. Besides, pyinstaller seems very resilient on paths format (supporting paths with space and both \ and / separators, even mixed together).

This way, all options can be formatted the same way, automatically detecting single and multi-value options. It also make the multi value options such as -add-data supporting to be written in pyinstaller.toml as single value instead of table.

Format options with argument as a single list item "--option=value" instead of 2 consecutive list item "--option", "value" which get me some error.