### PR TITLE
Remove limitation on not being able to define distpath when zipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Zip file is created in hatch \<dist\> folder, named as per standard naming conve
 
 Compatibility warnings:  
 `--name` option cannot be defined if several scripts are to be built.  
-`--distpath` option cannot be defined if built scripts are bundled in a zip file.  
-If any occurs, the option is ignored and a warning message is displayed.
+If this occurs, the option is ignored and a warning message is displayed.
 
 ## Example
 

--- a/hatch_pyinstaller/__init__.py
+++ b/hatch_pyinstaller/__init__.py
@@ -1,1 +1,1 @@
-version = "1.1.0.dev2"
+version = "1.1.0.dev3"


### PR DESCRIPTION
After some time using the zip option, I realized that we could define "distpath" option, as the final location of the zipped file.